### PR TITLE
Pass notify_assignees flag in /workorders PUT request

### DIFF
--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -267,7 +267,7 @@ const sharePointBtnUrl = computed(() => {
     const index = projects.value.findIndex(item => item.id === needle)
     const link = projects.value[index].link
 
-    // not sure why DB stores a string of "null" instead of keyword, but account of the string also...
+    // not sure why DB stores a string of "null" instead of keyword, but account for string variant also...
     return (link === null || link === 'null' || link === undefined || link.length < 1 ) ? 'https://kauffmaninc.sharepoint.com/' : link
   }
 })
@@ -530,6 +530,7 @@ function save() {
     method = 'post'
     url = `${runtimeConfig.public.API_URL}/subtask/` + data.subtask + `/workorder`
   } else {
+    data.notify_assignees = (notifyAssignees.value) ? true : false
     method = 'put'
     url = `${runtimeConfig.public.API_URL}/workorder/` + data.id
   }

--- a/components/FormComponentWorkOrder.vue
+++ b/components/FormComponentWorkOrder.vue
@@ -58,7 +58,14 @@
                 <v-col v-if="props.recordId" cols="12" sm="6" md="6">
                   <v-select v-model="editedItem.status" label="Status" :items="statuses" item-title="title" item-value="id"></v-select>
                 </v-col>
-                <v-col cols="12" sm="6" md="6">
+                <v-col v-if="props.recordId" cols="12" sm="6" md="6">
+                  <div class="d-flex">
+                    <v-autocomplete v-model="editedItem.assignees" label="Assignee(s)" :items="persons" item-title="title" item-value="value" multiple chips clearable></v-autocomplete>
+                    <v-checkbox-btn v-model="notifyAssignees" label="Notify Assignee(s)" class="pb-3" style="flex:none"></v-checkbox-btn>
+                  </div>
+                </v-col>
+
+                <v-col v-else cols="12" sm="6" md="6">
                   <v-autocomplete v-model="editedItem.assignees" label="Assignee(s)" :items="persons" item-title="title" item-value="value" multiple chips clearable></v-autocomplete>
                 </v-col>
 
@@ -166,6 +173,7 @@ const showUrlCopyConfirmMsg = ref(false)
 const displayShareBtn = ref(false)
 const shareUrl = ref('')
 const linkTemp = ref('')
+const notifyAssignees = ref(false)
 const props = defineProps({
     recordId: String,
     formAction: String,


### PR DESCRIPTION
This PR will provide the capability for users to whether or not a work order's assignee(s) are updated when a work order is updated.

Per spec requirements, this feature will only be available on existing records.