### PR TITLE
Add capability to view work orders by type/tag

### DIFF
--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -126,6 +126,7 @@ const isRecordPage = inject('isRecordPage')
 const filterByUserTrigger = inject('filterByUserTrigger')
 const showNonCompletedTrigger = inject('showNonCompletedTrigger')
 const showCompletedTrigger = inject('showCompletedTrigger')
+const viewByTypeTrigger = inject('viewByTypeTrigger')
 
 const showCompleted = ref(false)
 
@@ -227,6 +228,17 @@ watch(selectedAssignee, (currentValue, newValue) => {
   }
 })
 
+// reload table when viewByTypeTrigger is activated
+watch(viewByTypeTrigger, (currentValue, newValue) => {
+  if(currentValue !== newValue) {
+
+    showCompleted.value = false
+    // hide Filter by Assignee dropdown
+    // display Filter by Type dropdown
+    loadItems({ sortBy: [] })
+  }
+})
+
 
 function setMenuItems() {
   let navigationItems = []
@@ -247,6 +259,7 @@ function setMenuItems() {
       { 'label': 'My Work Orders', 'icon': 'mdi-account-box', 'filter_name': 'filterByUser', 'default_class': 'active' },
       { 'label': 'All Work Orders', 'icon': 'mdi-format-list-bulleted', 'filter_name': 'showNonCompleted', 'default_active': '' },
       { 'label': 'Completed', 'icon': 'mdi-playlist-check', 'filter_name': 'showCompleted', 'default_active': '' },
+      { 'label': 'Request View', 'icon': 'mdi-playlist-check', 'filter_name': 'viewByType', 'default_active': '' },
     ]
   }
 

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -6,7 +6,8 @@
       </v-card>
       <v-card v-else width="100vw">
         <div class="d-flex mb-2">
-          <v-autocomplete v-model="selectedAssignee" hide-details=true label="Filter by Assignee" :items="props.persons" class="pr-10"></v-autocomplete>
+          <v-autocomplete v-if="showFilterByAssigneeDropDown" v-model="selectedAssignee" hide-details=true label="Filter by Assignee" :items="props.persons" class="pr-10"></v-autocomplete>
+          <v-select v-if="showFilterByTypeDropDown" v-model="selectedType" hide-details=true label="Filter by Type" :items="props.tags" class="pr-10"></v-select>
           <v-text-field
             v-model="searchString"
             prepend-icon="mdi-magnify"
@@ -119,6 +120,9 @@ const data = ref([])
 const search = ref('')
 const searchString = ref('')
 const selectedAssignee = ref(userInfoStore.userInfo.id)
+const selectedType = ref('0')
+const showFilterByAssigneeDropDown = ref(true)
+const showFilterByTypeDropDown = ref(false)
 
 // use provide/inject pattern to receive data from layout
 const dialog = inject('dialog')
@@ -188,6 +192,9 @@ watch(() => route.query, () =>
 // set the showCompleted flag to false
 watch(filterByUserTrigger, (currentValue, newValue) => {
   if(currentValue !== newValue) {
+    showFilterByAssigneeDropDown.value = true
+    showFilterByTypeDropDown.value = false
+    selectedType.value = '0'
     showCompleted.value = false
     selectedAssignee.value = userInfoStore.userInfo.id
   }
@@ -196,7 +203,10 @@ watch(filterByUserTrigger, (currentValue, newValue) => {
 // sets the show complete filter to false, and sets the selected user to '0' if not already set to '0'
 watch(showNonCompletedTrigger, (currentValue, newValue) => {
   if(currentValue !== newValue) {
-    if(showCompleted.value === true || selectedAssignee.value != '0') {
+    if(showCompleted.value === true || selectedAssignee.value != '0' || showFilterByTypeDropDown.value === true) {
+      showFilterByAssigneeDropDown.value = true
+      showFilterByTypeDropDown.value = false
+      selectedType.value = '0'
       showCompleted.value = false
       if(selectedAssignee.value != '0') {
         selectedAssignee.value = '0' // this will trip the selectedAssignee watcher, and thus, perform loadItems() method again
@@ -212,6 +222,9 @@ watch(showNonCompletedTrigger, (currentValue, newValue) => {
 watch(showCompletedTrigger, (currentValue, newValue) => {
   if(currentValue !== newValue) {
     if(showCompleted.value === false || selectedAssignee.value != '0') {
+      showFilterByAssigneeDropDown.value = true
+      showFilterByTypeDropDown.value = false
+      selectedType.value = '0'
       showCompleted.value = true
       if(selectedAssignee.value != '0') {
         selectedAssignee.value = '0' // this will trip the selectedAssignee watcher, and thus, perform loadItems() method again
@@ -232,11 +245,23 @@ watch(selectedAssignee, (currentValue, newValue) => {
 // reload table when viewByTypeTrigger is activated
 watch(viewByTypeTrigger, (currentValue, newValue) => {
   if(currentValue !== newValue) {
-
     showCompleted.value = false
-    // hide Filter by Assignee dropdown
-    // display Filter by Type dropdown
-    loadItems({ sortBy: [] })
+    showFilterByAssigneeDropDown.value = false
+    showFilterByTypeDropDown.value = true
+    if(selectedAssignee.value != '0') {
+      selectedAssignee.value = '0' // this will trip the selectedAssignee watcher, and thus, perform loadItems() method again
+    } else {
+      loadItems({ sortBy: [] })
+    }
+  }
+})
+
+// reload table when selectedAssignee data is changed
+watch(selectedType, (currentValue, newValue) => {
+  if(currentValue !== newValue) {
+    if(showFilterByTypeDropDown.value === true) {
+      loadItems({ sortBy: [] })
+    }
   }
 })
 
@@ -297,6 +322,9 @@ function loadItems({ sortBy }) {
 
     axiosGetRequestURL = axiosGetRequestURL + statusQueryStr
   }
+
+  // filter by tag/type
+  if(selectedType.value !== '0') axiosGetRequestURL = axiosGetRequestURL + `&tag=` + selectedType.value
 
   // set sorting params here
   if(sortBy[0]) {

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -133,6 +133,7 @@ const showCompleted = ref(false)
 const props = defineProps({
   statuses: Array,
   persons: Array,
+  tags: Array,
 })
 
 const headers = [

--- a/components/WorkOrderSystem.vue
+++ b/components/WorkOrderSystem.vue
@@ -245,13 +245,15 @@ watch(selectedAssignee, (currentValue, newValue) => {
 // reload table when viewByTypeTrigger is activated
 watch(viewByTypeTrigger, (currentValue, newValue) => {
   if(currentValue !== newValue) {
-    showCompleted.value = false
-    showFilterByAssigneeDropDown.value = false
-    showFilterByTypeDropDown.value = true
-    if(selectedAssignee.value != '0') {
-      selectedAssignee.value = '0' // this will trip the selectedAssignee watcher, and thus, perform loadItems() method again
-    } else {
-      loadItems({ sortBy: [] })
+    if(showFilterByTypeDropDown.value === false) {
+      showCompleted.value = false
+      showFilterByAssigneeDropDown.value = false
+      showFilterByTypeDropDown.value = true
+      if(selectedAssignee.value != '0') {
+        selectedAssignee.value = '0' // this will trip the selectedAssignee watcher, and thus, perform loadItems() method again
+      } else {
+        loadItems({ sortBy: [] })
+      }
     }
   }
 })

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -168,7 +168,7 @@
     if(window.location.pathname === '/workorders') {
       setTimeout(() => {
         if(!isRecordPage.value) filteringMethod(activeFilter.value)
-      }, "100")
+      }, "150")
     }
   })
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -142,6 +142,9 @@
   const showCompletedTrigger = ref(0)
   provide('showCompletedTrigger', showCompletedTrigger)
 
+  const viewByTypeTrigger = ref(0)
+  provide('viewByTypeTrigger', viewByTypeTrigger)
+
   const isRecordPage = ref(false)
   provide('isRecordPage', isRecordPage)
 
@@ -202,6 +205,7 @@
       document.getElementById('filterByUser').classList.add('active')
       document.getElementById('showNonCompleted').classList.remove('active')
       document.getElementById('showCompleted').classList.remove('active')
+      document.getElementById('viewByType').classList.remove('active')
     }
 
     if (filter_name === 'showNonCompleted') {
@@ -210,6 +214,7 @@
       document.getElementById('showNonCompleted').classList.add('active')
       document.getElementById('filterByUser').classList.remove('active')
       document.getElementById('showCompleted').classList.remove('active')
+      document.getElementById('viewByType').classList.remove('active')
     }
 
     if (filter_name === 'showCompleted') {
@@ -218,6 +223,16 @@
       document.getElementById('showCompleted').classList.add('active')
       document.getElementById('filterByUser').classList.remove('active')
       document.getElementById('showNonCompleted').classList.remove('active')
+      document.getElementById('viewByType').classList.remove('active')
+    }
+
+    if (filter_name === 'viewByType') {
+      viewByTypeTrigger.value++
+
+      document.getElementById('viewByType').classList.add('active')
+      document.getElementById('filterByUser').classList.remove('active')
+      document.getElementById('showNonCompleted').classList.remove('active')
+      document.getElementById('showCompleted').classList.remove('active')
     }
   }
 

--- a/pages/workorders/index.vue
+++ b/pages/workorders/index.vue
@@ -3,7 +3,7 @@
   both root index.vue and /workorders/index.vue utilize it
 -->
 <template>
-  <work-order-system v-if="!loading" :statuses="statuses" :persons="persons"></work-order-system>
+  <work-order-system v-if="!loading" :statuses="statuses" :persons="persons" :tags="tags"></work-order-system>
 </template>
 
 <script setup>
@@ -18,6 +18,7 @@ const { $msal } = useNuxtApp()
 const runtimeConfig = useRuntimeConfig()
 const statuses = ref()
 const persons = ref()
+const tags = ref()
 const loading = inject('displayLoadingMessage')
 const isRecordPage = inject('isRecordPage')
 
@@ -58,6 +59,24 @@ onBeforeMount(async () => {
 
     // sort persons list
     persons.value = persons.value.sort((a, b) => 
+      a.title.localeCompare(b.title))
+
+  } catch (err) {
+    console.log(err)
+  }
+
+  try {
+    const response = await axios.get(`${runtimeConfig.public.API_URL}/tags`)
+      tags.value = response.data.data.map((item) => {
+        return {
+          title: item.name.toUpperCase(),
+          value: item.id
+        }
+      })
+      tags.value.push({'title': '-- None --', 'value': '0'})
+
+    // sort tags list
+    tags.value = tags.value.sort((a, b) => 
       a.title.localeCompare(b.title))
 
   } catch (err) {


### PR DESCRIPTION
This PR does the following:
- Displays a "Request View" tab in the nav bar when on the /workorders page.
- When "Request View is clicked", users will be provided a drop down where they can select a work order type, which will then display all non-completed work orders of that selected type. Default sort is none.
